### PR TITLE
Feature/use common exit target

### DIFF
--- a/cortex/__init__.py
+++ b/cortex/__init__.py
@@ -5,7 +5,6 @@ import logging
 import display
 import machine
 import game
-from tests import fake_gpio
 
 import pygame
 import time
@@ -34,7 +33,6 @@ class Cortex(object):
         self.logger.setLevel(logging.INFO)
         self.mode = OperationMode.ATTRACT
         self.game = game.Game()
-        #self.machine = machine.Machine(fake_gpio.FakeGPIO())
         self.machine = machine.Machine()
         self.display = display.Display(config, False)
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -44,13 +44,30 @@ class Game(object):
         self.log(logging.INFO, 'Process drop_ball target: {}'.format(target))
         value = self.get_target_value(target)
         self.score += value
-        self.remaining_balls -= 1
+        if target == 0:
+            # This is the special target which catches all balls
+            self.remaining_balls -= 1
+            self.pending_drops -= 1
+            if self.pending_drops < 0:
+                self.pending_drops = 0
+        else:
+            self.pending_drops += 1
         self.log(logging.INFO, 'Score is now {} ({})'.format(value, self.score))
         self.log(logging.INFO, 'Remaining balls: {}'.format(self.remaining_balls))
+        self.log(logging.INFO, 'Pending drops: {}'.format(self.pending_drops))
 
     def check_game_over(self):
-        '''Determine if the game is over.'''
-        if self.remaining_balls == 0:
+        '''Determine if the game is over.
+        
+        This will 'guess' that the game is over before the last ball passes
+        the catch-all target. This is done by keeping track of the balls that
+        it knows of passed the catch-all and those that have hit a scoring
+        target. If these add up to the total number of balls, the game is over.
+
+        This currently requires the balls to 'drain' into the next play area
+        before the next game starts.
+        '''
+        if self.remaining_balls - self.pending_drops == 0:
             self.game_over = True
             self.log(logging.INFO, 'Game is over.')
             return True
@@ -59,5 +76,6 @@ class Game(object):
     def start_game(self):
         self.score = 0
         self.remaining_balls = 9
+        self.pending_drops = 0
         self.game_over = False
         self.log(logging.INFO, 'Game is ready to start.')

--- a/machine/__init__.py
+++ b/machine/__init__.py
@@ -6,7 +6,8 @@ try:
     import RPi.GPIO as GPIO
 except RuntimeError:
     # This module can't be imported, assume running in test context
-    GPIO = None
+    import tests.fake_gpio
+    GPIO = tests.fake_gpio.FakeGPIO()
 
 DEFAULT_BOUNCETIME = 200
 


### PR DESCRIPTION
Use a catch-all target and track pending drops

The skeeball game is built such that there is no dedicated hole for the
missed target goal and all balls will pass through this area. As a
result, the sensor will need to be placed where all balls will pass by
it, even balls that have already hit a target.

To resolve this and still give the feeling of instant feedback when the
game is over, a pending_drops counter is added. This keeps track of the
number of balls 'in flight' between the scoring targets and the
catch-all area.